### PR TITLE
Add Google DeepVariant as a germline variant caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,11 @@ This release doesn't change how the containers are used, so it will continue usi
 
 ### Added
 
-### Changed
+- [#1](https://github.com/Sage-Bionetworks-Workflows/sarek/pull/1) - Add Google DeepVariant as a germline variant caller
 
 ### Fixed
 
 - [#2](https://github.com/Sage-Bionetworks-Workflows/sarek/pull/2) - Fix caching bug affecting a variable number of `MapReads` jobs due to non-deterministic state of `statusMap` during caching evaluation
-
-### Deprecated
-
-### Removed
 
 ## [2.7.1](https://github.com/nf-core/sarek/releases/tag/2.7.1) - Pårtejekna
 

--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -49,6 +49,9 @@
 * [Strelka2](https://pubmed.ncbi.nlm.nih.gov/30013048/)
   > Kim S, Scheffler K, Halpern AL, et al.: Strelka2: fast and accurate calling of germline and somatic variants. Nat Methods. 2018 Aug;15(8):591-594. doi: 10.1038/s41592-018-0051-x. Epub 2018 Jul 16. PubMed PMID: 30013048.
 
+* [Google DeepVariant](https://pubmed.ncbi.nlm.nih.gov/30247488/)
+  > Poplin R, Chang PC, Alexander D, Schwartz S, Colthurst T, Ku A, Newburger D, Dijamco J, Nguyen N, Afshar PT, Gross SS, Dorfman L, McLean CY, DePristo MA. A universal SNP and small-indel variant caller using deep neural networks. Nat Biotechnol. 2018 Nov;36(10):983-987. doi: 10.1038/nbt.4235. Epub 2018 Sep 24. PMID: 30247488.
+
 * [TIDDIT](https://pubmed.ncbi.nlm.nih.gov/28781756/)
   > Eisfeldt J, Vezzi F, Olason P, et al.: TIDDIT, an efficient and comprehensive structural variant caller for massive parallel sequencing data. F1000Res. 2017 May 10;6:664. doi: 10.12688/f1000research.11168.2. eCollection 2017. PubMed PMID: 28781756; PubMed Central PMCID: PMC5521161.
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Helpful contributors:
 * [gulfshores](https://github.com/gulfshores)
 * [pallolason](https://github.com/pallolason)
 * [silviamorins](https://github.com/silviamorins)
+* [BrunoGrandePhD](https://github.com/brunograndephd)
 
 ## Contributions & Support
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -101,6 +101,6 @@ process {
     container = "quay.io/biocontainers/msisensor-pro:1.1.a--hb3646a4_0"
   }
   withLabel:deepvariant {
-    container = "google/deepvariant:1.2.0"
+    container = "quay.io/sagebionetworks/deepvariant:1.2.0"
   }
 }

--- a/conf/base.config
+++ b/conf/base.config
@@ -100,4 +100,7 @@ process {
   withLabel:msisensor {
     container = "quay.io/biocontainers/msisensor-pro:1.1.a--hb3646a4_0"
   }
+  withLabel:deepvariant {
+    container = "google/deepvariant:1.2.0"
+  }
 }

--- a/docs/output.md
+++ b/docs/output.md
@@ -31,6 +31,7 @@ and processes data using the following steps:
     - [GATK Mutect2](#gatk-mutect2)
     - [samtools mpileup](#samtools-mpileup)
     - [Strelka2](#strelka2)
+    - [Google DeepVariant](#google-deepvariant)
     - [Sentieon DNAseq](#sentieon-dnaseq)
     - [Sentieon DNAscope](#sentieon-dnascope)
     - [Sentieon TNscope](#sentieon-tnscope)
@@ -290,6 +291,19 @@ Using [Strelka Best Practices](https://github.com/Illumina/strelka/blob/master/d
   - `VCF` with Tabix index
 
 For further reading and documentation see the [Strelka2 user guide](https://github.com/Illumina/strelka/blob/master/docs/userGuide/README.md).
+
+#### Google DeepVariant
+
+[Google DeepVariant](https://github.com/google/deepvariant) is a deep learning-based variant caller that takes aligned reads (in BAM or CRAM format), produces pileup image tensors from them, classifies each tensor using a convolutional neural network, and finally reports the results in a standard VCF or gVCF file.
+
+For all samples:
+
+**Output directory: `results/VariantCalling/[SAMPLE]/DeepVariant`**
+
+- `[SAMPLE].vcf.gz` 
+  - `VCF` file
+
+For further reading and documentation, see the [DeepVariant README](https://github.com/google/deepvariant#readme).
 
 #### Sentieon DNAseq
 

--- a/main.nf
+++ b/main.nf
@@ -2203,6 +2203,7 @@ process DeepVariant {
     when: 'deepvariant' in tools
 
     script:
+    extraOptions = params.intel_cpus ? "--call_variants_extra_args 'use_openvino=true'" : ""
     """
     /opt/deepvariant/bin/run_deepvariant \\
         --ref=${fasta} \\
@@ -2210,6 +2211,7 @@ process DeepVariant {
         --model_type=${modelType} \\
         --output_vcf=${idSample}.vcf.gz \\
         --output_gvcf=${idSample}.g.vcf.gz \\
+        ${extraOptions} \\
         --num_shards=${task.cpus}
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -62,6 +62,8 @@ params {
   umi = null // no umi
   read_structure1 = null // no umi
   read_structure2 = null // no umi
+  model_type = 'WGS'  // For DeepVariant
+  intel_cpus = false  // For DeepVariant
 
   // Annotation
   annotate_tools = null // Only with --step annotate

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -91,6 +91,8 @@
                         "mutect2",
                         "strelka",
                         "tiddit",
+                        "deepvariant",
+                        "DeepVariant",
                         "snpeff",
                         "vep",
                         "dnaseq",
@@ -354,7 +356,20 @@
                     "fa_icon": "fas fa-clipboard-list",
                     "description": "When processing UMIs, a read structure should always be provided for each of the fastq files.",
                     "help_text": "If the read does not contain any UMI, the structure will be +T (i.e. only template of any length).\nThe read structure follows a format adopted by different tools and described in the [fgbio documentation](https://github.com/fulcrumgenomics/fgbio/wiki/Read-Structures)"
-                }
+                },
+                "model_type": {
+                    "type": "string",
+                    "default": "WGS",
+                    "fa_icon": "fas fa-file-binary",
+                    "enum": [
+                        "WGS",
+                        "WES",
+                        "PACBIO",
+                        "HYBRID_PACBIO_ILLUMINA"
+                    ],
+                    "description": "Specify the relevant sequencing data type [WGS|WES|PACBIO|HYBRID_PACBIO_ILLUMINA].",
+                    "help_text": "Type of model to use for variant calling. Set this flag to use the default model associated with each type, and it will set necessary flags corresponding to each model."
+                },
             }
         },
         "annotation": {


### PR DESCRIPTION
This PR adds support for Google DeepVariant as a germline variant caller. It can be run on its own or alongside other variant callers. Note that the default model is WES, which needs to be change for WGS data. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
    - [x] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/sarek/tree/master/.github/CONTRIBUTING.md)
    - [x] If necessary, also make a PR on the nf-core/sarek _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
