### PR TITLE
Fix `MapReads` caching bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.7.1a](https://github.com/nf-core/sarek/releases/tag/2.7.1a) - Áhkká
+## [2.7.1-sage](https://github.com/Sage-Bionetworks-Workflows/sarek/tree/2.7.1-sage)
 
-Áhkká is one of the massifs just outside of the Sarek National Park.
-
-This patch release is a hotfix that doesn't change how the containers are used, so it will continue to use `sarek:2.7.1`,  `sarekvep:2.7.1.*`, and `sareksnpeff:2.7.1.*`.
+This release doesn't change how the containers are used, so it will continue using `sarek:2.7.1`,  `sarekvep:2.7.1.*`, and `sareksnpeff:2.7.1.*`.
 
 ### Added
 
@@ -17,7 +15,7 @@ This patch release is a hotfix that doesn't change how the containers are used, 
 
 ### Fixed
 
-- [#566](https://github.com/nf-core/sarek/pull/566) - Fix caching bug affecting a variable number of `MapReads` jobs due to non-deterministic state of `statusMap` during caching evaluation
+- [#2](https://github.com/Sage-Bionetworks-Workflows/sarek/pull/2) - Fix caching bug affecting a variable number of `MapReads` jobs due to non-deterministic state of `statusMap` during caching evaluation
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.1a](https://github.com/nf-core/sarek/releases/tag/2.7.1a) - Áhkká
+
+Áhkká is one of the massifs just outside of the Sarek National Park.
+
+This patch release is a hotfix that doesn't change how the containers are used, so it will continue to use `sarek:2.7.1`,  `sarekvep:2.7.1.*`, and `sareksnpeff:2.7.1.*`.
+
+### Added
+
+### Changed
+
+### Fixed
+
+- [#566](https://github.com/nf-core/sarek/pull/566) - Fix caching bug affecting a variable number of `MapReads` jobs due to non-deterministic state of `statusMap` during caching evaluation
+
+### Deprecated
+
+### Removed
+
 ## [2.7.1](https://github.com/nf-core/sarek/releases/tag/2.7.1) - Pårtejekna
 
 Pårtejekna is one of glaciers of the Pårte Massif.

--- a/docs/images/sarek_workflow.svg
+++ b/docs/images/sarek_workflow.svg
@@ -3457,7 +3457,7 @@
                width="150"
                id="rect2357-0" /></flowRegion><flowPara
              style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro'"
-             id="flowPara2359-7">2.7.1a</flowPara></flowRoot></g></g></g><g
+             id="flowPara2359-7">2.7.1-sage</flowPara></flowRoot></g></g></g><g
      id="g2024"><g
        id="g557-5"
        transform="matrix(0.63891071,0,0,-0.63891071,1686.6721,2304.9241)"><path

--- a/docs/images/sarek_workflow.svg
+++ b/docs/images/sarek_workflow.svg
@@ -3457,7 +3457,7 @@
                width="150"
                id="rect2357-0" /></flowRegion><flowPara
              style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro'"
-             id="flowPara2359-7">2.7.1</flowPara></flowRoot></g></g></g><g
+             id="flowPara2359-7">2.7.1a</flowPara></flowRoot></g></g></g><g
      id="g2024"><g
        id="g557-5"
        transform="matrix(0.63891071,0,0,-0.63891071,1686.6721,2304.9241)"><path

--- a/main.nf
+++ b/main.nf
@@ -4168,6 +4168,9 @@ def extractInfos(channel) {
         statusMap[idPatient, idSample] = status
         [idPatient] + it[3..-1]
     }
+    // This forces a roundtrip as a list to ensure that genderMap and
+    // statusMap are fully populated before being used downstream
+    channel = Channel.fromList(channel.toList().val)
     [genderMap, statusMap, channel]
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -246,7 +246,7 @@ manifest {
   description = 'An open-source analysis pipeline to detect germline or somatic variants from whole genome or targeted sequencing'
   mainScript = 'main.nf'
   nextflowVersion = '>=20.04.0'
-  version = '2.7.1a'
+  version = '2.7.1-sage'
 }
 
 // Return the minimum between requirements and a maximum limit to ensure that resource requirements don't go over

--- a/nextflow.config
+++ b/nextflow.config
@@ -246,7 +246,7 @@ manifest {
   description = 'An open-source analysis pipeline to detect germline or somatic variants from whole genome or targeted sequencing'
   mainScript = 'main.nf'
   nextflowVersion = '>=20.04.0'
-  version = '2.7.1'
+  version = '2.7.1a'
 }
 
 // Return the minimum between requirements and a maximum limit to ensure that resource requirements don't go over


### PR DESCRIPTION
This PR adds a single line of code to the `extractInfos()` function to ensure that the `genderMap` and `statusMap` maps are fully populated before being used downstream. Otherwise, they have a non-deterministic state that causes inconsistent caching behavior for the `MapReads` process. 

Aside from `main.nf`, the three other files were updated to use the `2.7.1-sage` version tag to represent an evolving version of Sarek built on top of `2.7.1`. 

See nf-core/sarek#555 for more context on how the issue was debugged. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] `CHANGELOG.md` is updated.