### PR TITLE
Use Quay.io copy of `sarek` container image

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -115,7 +115,7 @@ params {
 // Container slug
 // Stable releases should specify release tag (ie: `2.5.2`)
 // Developmental code should specify dev
-process.container = 'nfcore/sarek:2.7.1'
+process.container = 'quay.io/sagebionetworks/sarek:2.7.1'
 
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'


### PR DESCRIPTION
This one-line change is to move away from Docker Hub wherever possible because of rate limits. The version on Quay.io is a copy of what's on Docker Hub, which I created using the following commands: 

```console
docker pull nfcore/sarek:2.7.1
docker tag nfcore/sarek:2.7.1 quay.io/sagebionetworks/sarek:2.7.1
docker push quay.io/sagebionetworks/sarek:2.7.1
```

Note that I have not copied over the `sarekvep` container images because there are many of them (one per genome build), and we're not using VEP yet. 